### PR TITLE
docs: deploy boilerplate mkDocs wiki

### DIFF
--- a/docs/bounties/active.md
+++ b/docs/bounties/active.md
@@ -1,0 +1,20 @@
+# Active Bounties
+
+The following bounties are currently open and available for contributors.
+
+## How to Claim a Bounty
+
+1. Review the bounty description and requirements
+2. Comment on the relevant issue to express your intent
+3. Submit your work as a pull request or deliverable
+4. Once reviewed and accepted, payment will be processed
+
+## Open Bounties
+
+| Bounty | Description | Reward |
+|--------|-------------|--------|
+| Create Wiki | Deploy boilerplate mkDocs wiki including proposal, bounties, and FL0X token guide | 300 DNT, 300 FL0X |
+
+---
+
+*Check back regularly as new bounties are added.*

--- a/docs/bounties/paid.md
+++ b/docs/bounties/paid.md
@@ -1,0 +1,13 @@
+# Paid Bounties
+
+The following bounties have been completed and paid out.
+
+## History
+
+| Bounty | Description | Reward | Recipient |
+|--------|-------------|--------|-----------|
+| — | No paid bounties yet | — | — |
+
+---
+
+*This page is updated as bounties are completed and payments are confirmed.*

--- a/docs/fl0x-token.md
+++ b/docs/fl0x-token.md
@@ -1,0 +1,45 @@
+# How to Add FL0X Token
+
+This guide walks you through adding the FL0X token to your wallet.
+
+## Prerequisites
+
+- A compatible Web3 wallet (e.g., MetaMask)
+- Access to the network where FL0X is deployed
+
+## Steps
+
+### 1. Open Your Wallet
+
+Open MetaMask or your preferred Web3 wallet and ensure you are connected to the correct network.
+
+### 2. Add a Custom Token
+
+1. Click on **Assets** or **Tokens** in your wallet
+2. Select **Add Token** or **Import Token**
+3. Choose **Custom Token**
+
+### 3. Enter FL0X Token Details
+
+Fill in the following details:
+
+| Field | Value |
+|-------|-------|
+| Token Contract Address | *(see project announcements for the official address)* |
+| Token Symbol | FL0X |
+| Decimals | 18 |
+
+### 4. Confirm
+
+Click **Add Custom Token** and then **Import Tokens** to confirm. FL0X will now appear in your wallet.
+
+## Troubleshooting
+
+- Ensure you are on the correct network
+- Double-check the contract address from an official source
+- If the token does not appear, try refreshing your wallet
+
+## Resources
+
+- [Active Bounties](bounties/active.md)
+- [Proposal](proposal.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# Welcome to the FL0X Wiki
+
+This wiki contains documentation for the FL0X project, including the proposal, bounties, and guides for getting started with FL0X token.
+
+## Contents
+
+- [Proposal](proposal.md) — Overview of the FL0X proposal
+- [Active Bounties](bounties/active.md) — Currently open bounties
+- [Paid Bounties](bounties/paid.md) — Completed and paid bounties
+- [How to Add FL0X Token](fl0x-token.md) — Step-by-step guide to adding FL0X to your wallet

--- a/docs/proposal.md
+++ b/docs/proposal.md
@@ -1,0 +1,19 @@
+# Proposal
+
+## Overview
+
+FL0X is a community-driven project aimed at providing decentralized solutions. This page outlines the core proposal and its objectives.
+
+## Goals
+
+- Build an open, transparent ecosystem
+- Empower community members through bounties and contributions
+- Foster collaboration between developers and stakeholders
+
+## Details
+
+The FL0X proposal seeks to establish a sustainable token economy where contributors are rewarded for their work via bounties denominated in DNT and FL0X tokens.
+
+## Governance
+
+Decisions are made collaboratively by the community. Proposals are submitted, discussed, and voted on publicly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,20 @@
+site_name: FL0X Wiki
+site_description: Documentation for the FL0X project
+site_author: FL0X Community
+
+nav:
+  - Home: index.md
+  - Proposal: proposal.md
+  - Bounties:
+    - Active Bounties: bounties/active.md
+    - Paid Bounties: bounties/paid.md
+  - How to Add FL0X Token: fl0x-token.md
+
+theme:
+  name: material
+
+markdown_extensions:
+  - toc:
+      permalink: true
+  - tables
+  - fenced_code


### PR DESCRIPTION
## What
- Configured `mkdocs.yml` with site metadata, navigation, and material theme
- Added home page (`docs/index.md`) with links to all sections
- Added proposal page (`docs/proposal.md`)
- Added active bounties page (`docs/bounties/active.md`)
- Added paid bounties page (`docs/bounties/paid.md`)
- Added FL0X token setup guide (`docs/fl0x-token.md`)

## Why
- Fixes #1 (Create wiki)
- Deploys the required boilerplate mkDocs wiki covering the proposal, active/paid bounties, and how to add FL0X token

Closes #7

---
*Automated fix by [SnipeLink LLC](https://snipelink.com)*