### PR TITLE
docs: set up boilerplate mkDocs wiki

### DIFF
--- a/docs/add-fl0x-token.md
+++ b/docs/add-fl0x-token.md
@@ -1,0 +1,28 @@
+# How to Add FL0X Token
+
+Follow these steps to add the FL0X token to your compatible wallet (e.g. MetaMask).
+
+## Prerequisites
+
+- A Web3-compatible wallet (e.g. [MetaMask](https://metamask.io/))
+- Connected to the correct network
+
+## Steps
+
+1. Open your wallet and navigate to **Assets** or **Tokens**
+2. Click **Import Token** (or **Add Token**)
+3. Select **Custom Token**
+4. Enter the FL0X token contract address:
+   ```
+   <FL0X_CONTRACT_ADDRESS>
+   ```
+5. The token symbol (`FL0X`) and decimals should populate automatically
+6. Click **Add Custom Token** and confirm
+
+You should now see FL0X listed in your wallet assets.
+
+## Troubleshooting
+
+- Ensure you are connected to the correct network before importing
+- Double-check the contract address matches the official FL0X address
+- If the symbol does not auto-fill, enter `FL0X` manually

--- a/docs/bounties/active.md
+++ b/docs/bounties/active.md
@@ -1,0 +1,14 @@
+# Active Bounties
+
+The following bounties are currently open and available for community members to claim.
+
+| Task | Reward | Status |
+|------|--------|--------|
+| Create wiki | 300 DNT, 300 FL0X | Open |
+
+## How to Claim a Bounty
+
+1. Review the bounty description and requirements
+2. Comment on the relevant issue to express your intent
+3. Complete the work and submit a pull request or deliverable
+4. Once reviewed and merged, the reward will be distributed

--- a/docs/bounties/paid.md
+++ b/docs/bounties/paid.md
@@ -1,0 +1,9 @@
+# Paid Bounties
+
+The following bounties have been completed and paid out.
+
+| Task | Reward | Paid To |
+|------|--------|---------|
+| — | — | — |
+
+*No bounties have been paid out yet.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# Welcome to the FL0X Wiki
+
+This wiki serves as the central hub for information about the FL0X project.
+
+## Contents
+
+- [Proposal](proposal.md) — Learn about the FL0X project proposal
+- [Active Bounties](bounties/active.md) — View currently open bounties
+- [Paid Bounties](bounties/paid.md) — View completed and paid bounties
+- [How to Add FL0X Token](add-fl0x-token.md) — Step-by-step guide to adding FL0X to your wallet

--- a/docs/proposal.md
+++ b/docs/proposal.md
@@ -1,0 +1,19 @@
+# Proposal
+
+## Overview
+
+FL0X is a community-driven project aimed at building a decentralized ecosystem.
+
+## Goals
+
+- Foster open collaboration through bounties
+- Grow the FL0X token ecosystem
+- Reward community contributions with DNT and FL0X tokens
+
+## Details
+
+The project uses a bounty-based contribution model where community members can earn rewards by completing defined tasks. Bounties are denominated in DNT and FL0X tokens.
+
+## Governance
+
+Proposals and bounties are managed transparently through this wiki and associated community channels.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,20 @@
+site_name: FL0X Wiki
+site_description: Official documentation for the FL0X project
+site_author: FL0X Community
+
+nav:
+  - Home: index.md
+  - Proposal: proposal.md
+  - Bounties:
+    - Active Bounties: bounties/active.md
+    - Paid Bounties: bounties/paid.md
+  - How to Add FL0X Token: add-fl0x-token.md
+
+theme:
+  name: material
+
+markdown_extensions:
+  - toc:
+      permalink: true
+  - admonition
+  - tables


### PR DESCRIPTION
## Summary

## What
- Configured `mkdocs.yml` with site metadata, navigation, and material theme
- Added home page (`docs/index.md`) with navigation overview
- Added proposal page (`docs/proposal.md`) describing the FL0X project
- Added active bounties page (`docs/bounties/active.md`) listing open bounties
- Added paid bounties page (`docs/bounties/paid.md`) as a placeholder for completed bounties
- Added FL0X token setup guide (`docs/add-fl0x-token.md`) with wallet instructions

## Why
- Fixes #7 — deploys the required boilerplate mkDocs wiki covering the proposal, active/paid bounties, and FL0X token setup

## Changes

- Set up mkdocs.yml with site metadata, navigation structure, and material theme
- Add home page content with navigation overview
- Add proposal page content describing the FL0X project
- Add active bounties page with current open bounties
- Add paid bounties page as a placeholder for completed bounties
- Add FL0X token setup guide with step-by-step wallet instructions

## Testing

- Verified the changes align with the issue requirements
- Kept modifications minimal and surgical to reduce review burden

Closes #7