### PR TITLE
docs: deploy boilerplate mkDocs wiki

### DIFF
--- a/docs/bounties/active.md
+++ b/docs/bounties/active.md
@@ -1,0 +1,20 @@
+# Active Bounties
+
+Below is a list of currently open bounties. Anyone is welcome to contribute. Please review the requirements carefully before starting work.
+
+## How to Claim a Bounty
+
+1. Comment on the relevant GitHub issue to express interest
+2. Fork the repository and complete the work
+3. Submit a pull request referencing the issue
+4. Await review and approval from maintainers
+5. Receive your reward in DNT and/or FL0X tokens upon merge
+
+## Open Bounties
+
+| Issue | Description | Reward |
+|-------|-------------|--------|
+| [#1 Create Wiki](https://github.com) | Deploy boilerplate mkDocs wiki | 300 DNT, 300 FL0X |
+
+!!! note
+    This table is updated as new bounties are opened. Check back regularly for new opportunities.

--- a/docs/bounties/paid.md
+++ b/docs/bounties/paid.md
@@ -1,0 +1,12 @@
+# Paid Bounties
+
+This page tracks the history of completed and paid bounties. It serves as a transparent record of contributions and rewards.
+
+## Completed Bounties
+
+| Issue | Description | Contributor | Reward | Date |
+|-------|-------------|-------------|--------|------|
+| — | No paid bounties yet | — | — | — |
+
+!!! info
+    As bounties are completed and paid, they will be recorded here.

--- a/docs/fl0x-token.md
+++ b/docs/fl0x-token.md
@@ -1,0 +1,43 @@
+# How to Add FL0X Token
+
+This guide explains how to add the FL0X token to your wallet so you can receive and manage bounty rewards.
+
+## Prerequisites
+
+- A compatible Web3 wallet (e.g., MetaMask)
+- Connected to the correct network
+
+## Steps
+
+### 1. Open Your Wallet
+
+Open MetaMask or your preferred Web3 wallet and ensure you are connected to the correct network.
+
+### 2. Navigate to Import Token
+
+In MetaMask:
+
+1. Click the **Assets** tab
+2. Scroll down and click **Import tokens**
+
+### 3. Enter Token Details
+
+Fill in the following information:
+
+| Field | Value |
+|-------|-------|
+| Token Contract Address | *(see project repository or announcements)* |
+| Token Symbol | FL0X |
+| Token Decimal | 18 |
+
+### 4. Confirm Import
+
+Click **Add Custom Token**, then **Import Tokens** to confirm.
+
+The FL0X token will now appear in your wallet's asset list.
+
+## Troubleshooting
+
+- **Token not showing?** Ensure you are on the correct network.
+- **Wrong balance?** Try refreshing your wallet or re-importing the token.
+- **Need help?** Reach out via the community channels listed in the project repository.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# Welcome to the FL0X Wiki
+
+This wiki contains documentation for the FL0X project, including the project proposal, bounty information, and guides for interacting with the FL0X token.
+
+## Contents
+
+- [Proposal](proposal.md) — Overview of the FL0X project proposal
+- [Active Bounties](bounties/active.md) — Currently open bounties available to contributors
+- [Paid Bounties](bounties/paid.md) — History of completed and paid bounties
+- [How to Add FL0X Token](fl0x-token.md) — Step-by-step guide to adding the FL0X token to your wallet

--- a/docs/proposal.md
+++ b/docs/proposal.md
@@ -1,0 +1,32 @@
+# Proposal
+
+## Overview
+
+FL0X is a community-driven project aimed at building decentralized tooling and infrastructure. This proposal outlines the vision, objectives, and roadmap for the project.
+
+## Vision
+
+To create an open, transparent, and community-governed ecosystem where contributors are fairly rewarded for their work through on-chain bounties.
+
+## Objectives
+
+- Establish a bounty system using DNT and FL0X tokens
+- Build and maintain open-source tooling
+- Grow an active contributor community
+- Ensure transparent governance and fund allocation
+
+## Roadmap
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| 1 | Project setup and token deployment | Complete |
+| 2 | Bounty system launch | In Progress |
+| 3 | Community growth and tooling | Planned |
+
+## Governance
+
+All major decisions are made through community proposals. Token holders may participate in governance votes.
+
+## Funding
+
+Bounties are funded using DNT and FL0X tokens. Rewards are distributed upon successful completion and review of bounty deliverables.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,18 @@
+site_name: FL0X Wiki
+site_description: Documentation for the FL0X project
+site_url: https://fl0x.github.io/
+
+theme:
+  name: material
+
+nav:
+  - Home: index.md
+  - Proposal: proposal.md
+  - Active Bounties: bounties/active.md
+  - Paid Bounties: bounties/paid.md
+  - How to Add FL0X Token: fl0x-token.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary

## What
- Configured `mkdocs.yml` with site metadata, Material theme, and navigation
- Added home page (`docs/index.md`) with links to all sections
- Added project proposal page (`docs/proposal.md`)
- Added active bounties page (`docs/bounties/active.md`) including current open bounty
- Added paid bounties history page (`docs/bounties/paid.md`)
- Added FL0X token setup guide (`docs/fl0x-token.md`)

## Why
- Fixes #1 — Deploy boilerplate mkDocs wiki covering proposal, active bounties, paid bounties history, and FL0X token instructions

## Bounty
300 DNT, 300 FL0X

## Changes

- Set up mkdocs.yml with site metadata, material theme, and navigation structure
- Add home page content with navigation overview
- Add project proposal documentation
- Add active bounties page
- Add paid bounties history page
- Add FL0X token setup guide

## Testing

- Verified the changes align with the issue requirements
- Kept modifications minimal and surgical to reduce review burden

Closes #7